### PR TITLE
Upgrade to VS2015/17

### DIFF
--- a/BAPSController/BAPSController.cpp
+++ b/BAPSController/BAPSController.cpp
@@ -19,11 +19,9 @@ BAPSController::BAPSController()
 
 	if (hDll == 0)
 	{
-		this->hasUSBDevices = false;
+		// Initialise empty array and get out
+		this->serialNumbers = gcnew array<System::String^>(0);
 		return;
-	}
-	else {
-		this->hasUSBDevices = true;
 	}
 
 	USBm_FindDevices =      (USBm_FindDevices_type)GetProcAddress(hDll, "USBm_FindDevices");
@@ -190,7 +188,7 @@ void BAPSController::runHelper()
 				USBm_DirectionB(i, 0x00, 0xFF);
 				USBm_WriteB(i, 0xFF);
 			}
-		
+
 			/* Swap in the new names and offsets */
 			serialNumbers = newSerialNumbers;
 			deviceCount = newDeviceCount;
@@ -203,15 +201,6 @@ void BAPSController::runHelper()
 
 array<System::String^>^ BAPSController::getSerialNumbers()
 {
-	if (hasUSBDevices == true) {
-		return safe_cast<array<System::String^>^>(serialNumbers->Clone());
-	} else {
-		array<System::String^>^ empty = gcnew array<System::String^>(0);
-		return empty;
-	}
-}
-
-bool BAPSController::hasUSB()
-{
-	return hasUSBDevices;
+	// Just returns empty array if no usb
+	return safe_cast<array<System::String^>^>(serialNumbers->Clone());
 }

--- a/BAPSController/BAPSController.h
+++ b/BAPSController/BAPSController.h
@@ -8,7 +8,7 @@ using namespace System;
 
 
 namespace BAPSControllerAssembly
-{	
+{
 	public delegate void SignalCallback(System::String^, int);
 
 	public ref class BAPSController
@@ -28,7 +28,6 @@ namespace BAPSControllerAssembly
 			}
 		}
 		array<System::String^>^ getSerialNumbers();
-		bool hasUSB();
 	private:
 		void runHelper();
 		HINSTANCE hDll;
@@ -77,12 +76,11 @@ namespace BAPSControllerAssembly
 		USBm_Copyright_type         USBm_Copyright;
 		USBm_About_type             USBm_About;
 		USBm_Version_type           USBm_Version;
-		
+
 		int deviceCount;
 		array<System::String^>^ serialNumbers;
 		array<unsigned char>^ lastByteA;
 		array<unsigned char>^ lastByteB;
-		bool hasUSBDevices;
 		bool quit;
 		System::Threading::Thread^ pollThread;
 		SignalCallback^ callback;

--- a/BAPSServerAssembly/BAPSController.h
+++ b/BAPSServerAssembly/BAPSController.h
@@ -27,9 +27,10 @@ namespace BAPSServerAssembly
 				}
 			}
 
+			// Defined, but does nothing if no usb device is defined
+			bapsController2 = gcnew BAPSControllerAssembly::BAPSController();
 			if (CONFIG_GETINT(CONFIG_BAPSCONTROLLER2ENABLED) == CONFIG_YES_VALUE)
 			{
-				bapsController2 = gcnew BAPSControllerAssembly::BAPSController();
 				bapsController2->run(gcnew BAPSControllerAssembly::SignalCallback(handleSignal));
 			}
 		}

--- a/BAPSServerAssembly/ClientInstance_config.cpp
+++ b/BAPSServerAssembly/ClientInstance_config.cpp
@@ -9,7 +9,7 @@ using namespace BAPSServerAssembly;
 #define BEGIN_CONFIG_BLOCK() ClientManager::getConfigLock();
 #define END_CONFIG_BLOCK() ClientManager::releaseConfigLock();
 
-/** 
+/**
  *  WORK NEEDED: validation functions, post-set functions for refreshing server
  *				 services with the new config values, security stuff
 **/
@@ -21,14 +21,14 @@ BEGIN_ACTION_BLOCKED1(sendOption,int optionid)
 {
 	/** The mode mask flips the bit to say this is an option not a count **/
 	Command cmd = BAPSNET_CONFIG | BAPSNET_OPTION | BAPSNET_CONFIG_MODEMASK;
-	/** 
+	/**
 		*  If the option is an indexed option the value field is set to the
 		*  controlling option's id. (This value is arbitrary using this value
 		*  is easiest
 	**/
 	if (CONFIG_ISINDEXED(optionid))
 	{
-		cmd |= BAPSNET_CONFIG_USEVALUEMASK;	
+		cmd |= BAPSNET_CONFIG_USEVALUEMASK;
 		cmd |= CONFIG_INDEXOPTION(optionid);
 	}
 	/** Send the optionid, optionDescription and optionType **/
@@ -38,7 +38,7 @@ END_ACTION_UNBLOCK();
 
 BEGIN_ACTION_BLOCKED0(sendAllOptions)
 {
-	/** 
+	/**
 	 *  Number of options is always CONFIG_LASTOPTION as it
 	 *  is at the end of the enum
 	**/
@@ -78,18 +78,14 @@ BEGIN_ACTION_BLOCKED1(sendAllOptionChoices, u32int optionid)
 	if (optionid == CONFIG_BAPSCONTROLLER2SERIAL)
 	{
 		ConfigStringChoices^ bapsController2Choices = gcnew ConfigStringChoices();
-		
-		// Initialise 
-		array<System::String^>^ serials = gcnew array<System::String^>(0);
-		if (CONFIG_GETINT(CONFIG_BAPSCONTROLLER2ENABLED) == CONFIG_YES_VALUE) {
-			serials = BAPSController::getBAPSController2Serials();
-		}
 
+		array<System::String^>^ serials = BAPSController::getBAPSController2Serials();
 		for (int i = 0 ; i < serials->Length ; i++)
 		{
 			bapsController2Choices->add(serials[i], serials[i], (i==0));
 		}
 		bapsController2Choices->add("none","none", (serials->Length==0));
+
 		safe_cast<ConfigDescriptorStringChoice^>(ConfigManager::configDescriptions[CONFIG_BAPSCONTROLLER2SERIAL])->setChoices(bapsController2Choices);
 		if (CONFIG_GETINT(CONFIG_BAPSCONTROLLER2DEVICECOUNT) < ((serials->Length==0)?1:serials->Length))
 		{
@@ -97,11 +93,11 @@ BEGIN_ACTION_BLOCKED1(sendAllOptionChoices, u32int optionid)
 		}
 	}
 
-	/** 
+	/**
 	 *  Should be called for any CONFIG_TYPE_CHOICE option
 	 *  returns all the possible choices the option can be.
 	**/
-	/** 
+	/**
 	 *  If the specified option:
 	 *  a) is not a valid option
 	 *  b) is not a CHOICE type
@@ -115,7 +111,7 @@ BEGIN_ACTION_BLOCKED1(sendAllOptionChoices, u32int optionid)
 		return;
 	}
 
-	/** 
+	/**
 	 *  We are certain now that the option is of CHOICE type, so cast
 	 *  its descriptor to the choice superclass
 	**/
@@ -163,7 +159,7 @@ BEGIN_ACTION_BLOCKED3(sendOptionConfigSettings, int optionid, bool shouldBroadca
 			cmd &= ~BAPSNET_CONFIG_VALUEMASK;
 			/** Set the value field to the current index **/
 			cmd |= j;
-			/** 
+			/**
 				*  Send the correct type of data, the CONFIG_TYPE informs the
 				*  client of what to expect
 			**/
@@ -203,7 +199,7 @@ BEGIN_ACTION_BLOCKED3(sendOptionConfigSettings, int optionid, bool shouldBroadca
 				}
 				break;
 			default:
-				/** This case will cause a client and/or server to hang, it will be a programming error server side **/ 
+				/** This case will cause a client and/or server to hang, it will be a programming error server side **/
 				LogManager::write(System::String::Concat("The following option has an invalid type:\n", CONFIG_KEY(optionid), CONFIG_DESC(optionid)), LOG_ERROR, LOG_CONFIG);
 				break;
 			}
@@ -249,7 +245,7 @@ BEGIN_ACTION_BLOCKED3(sendOptionConfigSettings, int optionid, bool shouldBroadca
 			}
 			break;
 		default:
-			/** This case will cause a client and/or server to hang, it will be a programming error server side **/ 
+			/** This case will cause a client and/or server to hang, it will be a programming error server side **/
 			LogManager::write(System::String::Concat("The following option has an invalid type:\n", CONFIG_KEY(optionid), CONFIG_DESC(optionid)), LOG_ERROR, LOG_CONFIG);
 			break;
 		}
@@ -260,7 +256,7 @@ END_ACTION_UNBLOCK();
 BEGIN_ACTION_BLOCKED0(sendAllConfigSettings)
 {
 	/** Finds all valid settings and sends them to the client **/
-	/** 
+	/**
 	 *  The count is more complex as we do not know easily how many settings
 	 *  there are due to indexed options, this short loop works this out
 	**/
@@ -536,7 +532,7 @@ BEGIN_ACTION_BLOCKED1(sendUser, System::String^ username)
 		ClientManager::send(this, cmd, const_cast<System::String^>(UserManager::UserResultText[UR_USERNOTEXIST]));
 		return;
 	}
-	
+
 	Command cmd = BAPSNET_CONFIG | BAPSNET_USER | BAPSNET_CONFIG_MODEMASK;
 	ClientManager::send(this, cmd, username, GETPERM(username));
 }

--- a/BAPSServerAssembly/ConfigManager.cpp
+++ b/BAPSServerAssembly/ConfigManager.cpp
@@ -71,7 +71,7 @@ void ConfigManager::initConfigManager()
 		// WORK NEEDED: better exception system
 		throw gcnew System::Exception("device enumeration failed");
 	}
-	
+
 	ConfigStringChoices^ deviceChoices = gcnew ConfigStringChoices();
 	int i = 0;
 	bool isDefault = true;
@@ -82,7 +82,7 @@ void ConfigManager::initConfigManager()
 		{
 			isDefault = false;
 		}
-		
+
 		deviceChoices->add(LPCWSTRToString(devices->GetDevice(i)->GetDescription()),
 						   LPCWSTRToString(devices->GetDevice(i)->GetID()),
 						   isDefault);
@@ -144,22 +144,15 @@ void ConfigManager::initConfigManager()
 	BAPSControllerAssembly::BAPSController^ bc = gcnew BAPSControllerAssembly::BAPSController();
 
 	ConfigStringChoices^ bapsController2Choices = gcnew ConfigStringChoices();
-	array<System::String^>^ serials = {};
 
-	if (bc->hasUSB() == true) {
-		serials = bc->getSerialNumbers();
-		for (int i = 0; i < serials->Length; i++)
-		{
-			bapsController2Choices->add(serials[i], serials[i], (i == 0));
-		}
-
-		bapsController2Choices->add("none", "none", (serials->Length == 0));
-	}
-	else
+	array<System::String^>^ serials = bc->getSerialNumbers();
+	for (int i = 0; i < serials->Length; i++)
 	{
-		bapsController2Choices->add("none", "none", true);
+		bapsController2Choices->add(serials[i], serials[i], (i == 0));
 	}
-	
+
+	bapsController2Choices->add("none", "none", (serials->Length == 0));
+
 	delete bc;
 
 	configDescriptions[CONFIG_BAPSCONTROLLER2ENABLED] = gcnew ConfigDescriptorIntChoice("BAPSController2Enabled", "BAPS USB Controller Enabled", noYesChoices, CA_SU_ONLY);
@@ -180,7 +173,7 @@ void ConfigManager::initConfigManager()
 	configErrors[CE_BADMASK] = "Badly formatted mask";
 	configErrors[CE_RESTRICTIONEXISTS] = "IP restriction already exists";
 	configErrors[CE_RESTRICTIONNOTEXIST] = "IP restriction does not exist";
-	
+
 }
 
 void ConfigManager::closeConfigManager()


### PR DESCRIPTION
Introduces a rough BAPSSetupV2, it installs (and actually adds registry items, which the old one doesn't seem to do). It's rough because it just pops up a popup to request the login details the service should run as. In Studio 1 right now, this runs as the LocalService. This installer doesn't support this at the moment.

Todo:

- [x] Make BAPS Presenter restart on crash, as it used to. - EDIT: turns out this is determined by if you are building a Debug or Release version.

Fixes #2 